### PR TITLE
Change from multiple threads to single loop

### DIFF
--- a/src/main/adapters/messaging/SynchronizedCommandQueue.h
+++ b/src/main/adapters/messaging/SynchronizedCommandQueue.h
@@ -11,8 +11,10 @@
 /**
  * An implementation of the ICommandQueue that is thread safe. The implementation
  * of the push and pop is made in a way that every thread that tries to pop is
- * put into pause as long as no command has been pushed. Once a commen is pushed
- * the queue wakes up the thread that could immediately pop the command.
+ * put into pause as long as no command has been pushed.
+ *
+ * The queue still uses a mutex to lock the access because the console runs on
+ * another thread than the ones that handles the rest of the system.
  */
 class SynchronizedCommandQueue : public ICommandQueue
 {
@@ -26,8 +28,8 @@ class SynchronizedCommandQueue : public ICommandQueue
 public:
     /**
      * It creates an instance of the queue to be used to send commands to the Kiosk.
-     * The queue offers 2 thread safe operations, push and pop. The pop puts the caller
-     * in idle using the wait, while the push wakes it up using the notify_one.
+     * The queue offers 2 thread safe operations, push and pop. The push stores something in the queue,
+     * while the pop allows to obtain it.
      * @param stop_token the stop token is required to wake up any thread that has been
      * paused in the pop function.
      */
@@ -37,49 +39,27 @@ public:
 
     void push(KioskCommand cmd) override
     {
-        {
-            // I activate the lock...
-            std::lock_guard<std::mutex> lock(m_mutex);
-            // ... and push into the queue
-            m_queue.push(cmd);
-        }
-
-        // I notify any sleeping thread that the queue has something
-        m_cv.notify_one();
+        // I activate the lock...
+        std::lock_guard<std::mutex> lock(m_mutex);
+        // ... and push into the queue
+        m_queue.push(cmd);
     }
 
-    KioskCommand pop() override
+    std::optional<KioskCommand> pop() override
     {
-        // I just need it for later...
-        KioskCommand cmd = KioskCommand{CommandType::IDLE};
-
+        // to avoid an unnecessary long lock ...
+        if (m_queue.empty())
         {
-            // I activate the lock...
-            std::unique_lock<std::mutex> lock(m_mutex);
-
-            // and I put the thread into idle using the condition variable.
-            // Here I wait for notify, and then I check the queue, or for a change in the stop token. When one of the two
-            // happens, I lock the mutex and go to the next instruction
-            m_cv.wait(lock, stop_token, [this]
-            {
-                // if  notify comes and the queue is empty I simply sleep again
-                return !m_queue.empty();
-            });
-
-            // If the stop token has been requested...
-            if (stop_token.stop_requested())
-            {
-                // ... I shut down the system sending one last message
-                return KioskCommand{CommandType::STOP};
-            }
-
-
-            // I take the command and pop the queue...
-            cmd = m_queue.front();
-            m_queue.pop();
+            return std::nullopt;
         }
 
-        // Outside the lock, reducing the 'lock' size, I return the command
+        // Is not empty, so I lock for really short ...
+        std::unique_lock<std::mutex> lock(m_mutex);
+
+        // and return the command
+        KioskCommand cmd = m_queue.front();
+        m_queue.pop();
+        
         return cmd;
     }
 };

--- a/src/main/core/Kiosk.cpp
+++ b/src/main/core/Kiosk.cpp
@@ -20,29 +20,31 @@ void Kiosk::step()
 {
     auto cmd = m_queue.pop();
 
-    IKioskState& nextState = m_currentState->handleCommand(*this, cmd);
-    if (&nextState != m_currentState)
+    if (cmd.has_value())
     {
-        m_log.log(
-            "Transition: " +
-            to_string(m_currentState->getStatus()) +
-            " into " +
-            to_string(nextState.getStatus()));
+        IKioskState& nextState = m_currentState->handleCommand(*this, cmd.value());
+        if (&nextState != m_currentState)
+        {
+            m_log.log(
+                "Transition: " +
+                to_string(m_currentState->getStatus()) +
+                " into " +
+                to_string(nextState.getStatus()));
 
-        // state changes...
-        m_currentState = &nextState;
+            // state changes...
+            m_currentState = &nextState;
 
-        // Information broadcasting
-        m_view.notifyMessage(m_currentState->getMessage());
-        // send the new status to all the listeners,
-        this->notifyListeners(m_currentState->getStatus());
-    }
-    else
-    {
-        m_log.log(
-            "No transition for: " +
-            to_string(m_currentState->getStatus()));
-
+            // Information broadcasting
+            m_view.notifyMessage(m_currentState->getMessage());
+            // send the new status to all the listeners,
+            this->notifyListeners(m_currentState->getStatus());
+        }
+        else
+        {
+            m_log.log(
+                "No transition for: " +
+                to_string(m_currentState->getStatus()));
+        }
     }
 }
 

--- a/src/main/core/Kiosk.h
+++ b/src/main/core/Kiosk.h
@@ -6,6 +6,7 @@
 #define GRABSTATION_KIOSK_H
 
 #pragma once
+#include <cmath>
 #include <iostream>
 #include <optional>
 
@@ -50,7 +51,6 @@ class Kiosk
 
     int m_rows;
     int m_cols;
-
 
 
     /**
@@ -138,7 +138,8 @@ public:
     [[nodiscard]] std::optional<Coordinate> validateCoordinates(Coordinate currentCoordinates) const
     {
         // checking against grid size
-        if (currentCoordinates.x > m_cols || currentCoordinates.y > m_rows)
+        if (static_cast<int>(std::round(currentCoordinates.x)) > m_cols ||
+            static_cast<int>(std::round(currentCoordinates.y)) > m_rows)
         {
             std::cout << "Too big coordinates. " << std::endl;
             std::cout << "Actual size: " << m_cols << " and " << m_rows << ". " << std::endl;

--- a/src/main/core/ports/IArmPort.h
+++ b/src/main/core/ports/IArmPort.h
@@ -5,12 +5,11 @@
 #ifndef GRABSTATION_ARMPORT_H
 #define GRABSTATION_ARMPORT_H
 #pragma once
-#include <atomic>
 
 struct Coordinate
 {
-    int x;
-    int y;
+    float x;
+    float y;
 };
 
 /**

--- a/src/main/core/ports/ICommandQueue.h
+++ b/src/main/core/ports/ICommandQueue.h
@@ -4,7 +4,7 @@
 
 #ifndef GRABSTATION_KIOSKQUEUE_H
 #define GRABSTATION_KIOSKQUEUE_H
-#include <mutex>
+#include <optional>
 #include <queue>
 
 #include "commands/KioskCommand.h"
@@ -19,7 +19,7 @@ public:
 
     virtual void push(KioskCommand cmd) = 0;
 
-    virtual KioskCommand pop() = 0;
+    virtual std::optional<KioskCommand> pop() = 0;
 };
 
 #endif //GRABSTATION_KIOSKQUEUE_H

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -50,25 +50,6 @@ int main()
         async_logger.flush(master_token);
     });
 
-
-    std::jthread arm_simulator_thread([&simulator = arm, &master_token]()
-    {
-        while (!master_token.stop_requested())
-        {
-            simulator.move();
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-        }
-    });
-
-    std::jthread user_inactive_watchdog_thread([&monitor = user_inactive_watchdog, &master_token]()
-    {
-        while (!master_token.stop_requested())
-        {
-            monitor.check();
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-        }
-    });
-
     // this initializes the Kiosk
     kiosk.start();
     // 7. Main Logic Loop (The Heartbeat)
@@ -77,6 +58,8 @@ int main()
     {
         while (!master_token.stop_requested())
         {
+            arm.move();
+            user_inactive_watchdog.check();
             kiosk.step();
         }
     }

--- a/src/test/adapters/simulation/test_arm_simulation.cpp
+++ b/src/test/adapters/simulation/test_arm_simulation.cpp
@@ -12,7 +12,7 @@
 class MockQueue : public ICommandQueue
 {
     MOCK_METHOD(void, push, (KioskCommand cmd), (override));
-    MOCK_METHOD(KioskCommand, pop, (), (override));
+    MOCK_METHOD(std::optional<KioskCommand>, pop, (), (override));
 };
 
 // now I write the test base class, that uses the mocks to create a kiosk
@@ -20,12 +20,10 @@ class SimulatedArmTest : public ::testing::Test
 {
 public:
     MockQueue queue;
-    std::unique_ptr<SimulatedArm> simulated_arm;
 
 protected:
     void SetUp() override
     {
-        simulated_arm = std::make_unique<SimulatedArm>();
     }
 };
 
@@ -33,32 +31,32 @@ protected:
 // testing
 TEST_F(SimulatedArmTest, MovementOnX_Axis)
 {
-    simulated_arm->setDestination(Coordinate(5, 0));
+    std::unique_ptr<SimulatedArm> simulated_arm = std::make_unique<SimulatedArm>();
+    simulated_arm->setDestination(Coordinate(5.0f, 0.0f));
 
-    EXPECT_EQ(simulated_arm->getCurrentPosition().x, 0);
+    EXPECT_EQ(static_cast<int>(std::round(simulated_arm->getCurrentPosition().x)), 0);
 
-    simulated_arm->move();
-    simulated_arm->move();
-    simulated_arm->move();
-    simulated_arm->move();
-    simulated_arm->move();
+    while (!simulated_arm->hasReachedTarget())
+    {
+        simulated_arm->move();
+    }
 
-    EXPECT_EQ(simulated_arm->getCurrentPosition().x, 5);
+    EXPECT_EQ(static_cast<int>(std::round(simulated_arm->getCurrentPosition().x)), 5);
 }
 
 
 // testing
 TEST_F(SimulatedArmTest, MovementOnY_Axis)
 {
-    simulated_arm->setDestination(Coordinate(0, 5));
+    std::unique_ptr<SimulatedArm> simulated_arm = std::make_unique<SimulatedArm>();
+    simulated_arm->setDestination(Coordinate(0.0f, 5.0f));
 
-    EXPECT_EQ(simulated_arm->getCurrentPosition().x, 0);
+    EXPECT_EQ(static_cast<int>(std::round(simulated_arm->getCurrentPosition().y)), 0);
 
-    simulated_arm->move();
-    simulated_arm->move();
-    simulated_arm->move();
-    simulated_arm->move();
-    simulated_arm->move();
+    while (!simulated_arm->hasReachedTarget())
+    {
+        simulated_arm->move();
+    }
 
-    EXPECT_EQ(simulated_arm->getCurrentPosition().y, 5);
+    EXPECT_EQ(static_cast<int>(std::round(simulated_arm->getCurrentPosition().y)), 5);
 }

--- a/src/test/core/states/test_IdleStates_transitions.cpp
+++ b/src/test/core/states/test_IdleStates_transitions.cpp
@@ -8,6 +8,12 @@
 #include "gmock/gmock-function-mocker.h"
 
 // mock versions of the classes not relevant for this tests
+class MockLogger : public ILogger
+{
+public:
+    MOCK_METHOD(void, log, (const std::string& message), (override));
+};
+
 class MockArm : public IArmPort
 {
 public:
@@ -26,7 +32,7 @@ class MockView : public IViewPort
 class MockQueue : public ICommandQueue
 {
     MOCK_METHOD(void, push, (KioskCommand cmd), (override));
-    MOCK_METHOD(KioskCommand, pop, (), (override));
+    MOCK_METHOD(std::optional<KioskCommand>, pop, (), (override));
 };
 
 
@@ -34,6 +40,7 @@ class IdleStatesTest : public ::testing::Test
 {
 public:
     MockQueue queue;
+    MockLogger mock_logger;
     MockArm mock_arm;
     MockView mock_view;
     std::unique_ptr<Kiosk> kiosk;
@@ -41,7 +48,7 @@ public:
 protected:
     void SetUp() override
     {
-        kiosk = std::make_unique<Kiosk>(queue, mock_view, mock_arm, 5, 5);
+        kiosk = std::make_unique<Kiosk>(queue, mock_view, mock_arm, mock_logger, 5, 5);
     }
 };
 

--- a/src/test/core/states/test_InitializingStates_transitions.cpp
+++ b/src/test/core/states/test_InitializingStates_transitions.cpp
@@ -8,6 +8,12 @@
 #include "gmock/gmock-function-mocker.h"
 
 // mock versions of the classes not relevant for this tests
+class MockLogger : public ILogger
+{
+public:
+    MOCK_METHOD(void, log, (const std::string& message), (override));
+};
+
 class MockArm : public IArmPort
 {
 public:
@@ -26,7 +32,7 @@ class MockView : public IViewPort
 class MockQueue : public ICommandQueue
 {
     MOCK_METHOD(void, push, (KioskCommand cmd), (override));
-    MOCK_METHOD(KioskCommand, pop, (), (override));
+    MOCK_METHOD(std::optional<KioskCommand>, pop, (), (override));
 };
 
 
@@ -34,6 +40,7 @@ class InitializingStatesTest : public ::testing::Test
 {
 public:
     MockQueue queue;
+    MockLogger mock_logger;
     MockArm mock_arm;
     MockView mock_view;
     std::unique_ptr<Kiosk> kiosk;
@@ -41,7 +48,7 @@ public:
 protected:
     void SetUp() override
     {
-        kiosk = std::make_unique<Kiosk>(queue, mock_view, mock_arm, 5, 5);
+        kiosk = std::make_unique<Kiosk>(queue, mock_view, mock_arm, mock_logger, 5, 5);
     }
 };
 

--- a/src/test/core/states/test_approachingItemStates_transitions.cpp
+++ b/src/test/core/states/test_approachingItemStates_transitions.cpp
@@ -8,6 +8,12 @@
 #include "gmock/gmock-function-mocker.h"
 
 // mock versions of the classes not relevant for this tests
+class MockLogger : public ILogger
+{
+public:
+    MOCK_METHOD(void, log, (const std::string& message), (override));
+};
+
 class MockArm : public IArmPort
 {
 public:
@@ -26,7 +32,7 @@ class MockView : public IViewPort
 class MockQueue : public ICommandQueue
 {
     MOCK_METHOD(void, push, (KioskCommand cmd), (override));
-    MOCK_METHOD(KioskCommand, pop, (), (override));
+    MOCK_METHOD(std::optional<KioskCommand>, pop, (), (override));
 };
 
 
@@ -34,6 +40,7 @@ class ApproachingItemStatesTest : public ::testing::Test
 {
 public:
     MockQueue queue;
+    MockLogger mock_logger;
     MockArm mock_arm;
     MockView mock_view;
     std::unique_ptr<Kiosk> kiosk;
@@ -41,7 +48,7 @@ public:
 protected:
     void SetUp() override
     {
-        kiosk = std::make_unique<Kiosk>(queue, mock_view, mock_arm, 5, 5);
+        kiosk = std::make_unique<Kiosk>(queue, mock_view, mock_arm, mock_logger, 5, 5);
     }
 };
 

--- a/src/test/core/states/test_processingSelectionStates_transitions.cpp
+++ b/src/test/core/states/test_processingSelectionStates_transitions.cpp
@@ -8,6 +8,12 @@
 #include "gmock/gmock-function-mocker.h"
 
 // mock versions of the classes not relevant for this tests
+class MockLogger : public ILogger
+{
+public:
+    MOCK_METHOD(void, log, (const std::string& message), (override));
+};
+
 class MockArm : public IArmPort
 {
 public:
@@ -26,7 +32,7 @@ class MockView : public IViewPort
 class MockQueue : public ICommandQueue
 {
     MOCK_METHOD(void, push, (KioskCommand cmd), (override));
-    MOCK_METHOD(KioskCommand, pop, (), (override));
+    MOCK_METHOD(std::optional<KioskCommand>, pop, (), (override));
 };
 
 
@@ -34,6 +40,7 @@ class ProcessingSelectionStatesTest : public ::testing::Test
 {
 public:
     MockQueue queue;
+    MockLogger mock_logger;
     MockArm mock_arm;
     MockView mock_view;
     std::unique_ptr<Kiosk> kiosk;
@@ -41,7 +48,7 @@ public:
 protected:
     void SetUp() override
     {
-        kiosk = std::make_unique<Kiosk>(queue, mock_view, mock_arm, 5, 5);
+        kiosk = std::make_unique<Kiosk>(queue, mock_view, mock_arm, mock_logger, 5, 5);
     }
 };
 

--- a/src/test/core/test_kiosk.cpp
+++ b/src/test/core/test_kiosk.cpp
@@ -8,6 +8,12 @@
 #include "gmock/gmock-function-mocker.h"
 
 // mock versions of the classes not relevant for this tests
+class MockLogger : public ILogger
+{
+public:
+    MOCK_METHOD(void, log, (const std::string& message), (override));
+};
+
 class MockArm : public IArmPort
 {
 public:
@@ -26,7 +32,7 @@ class MockView : public IViewPort
 class MockQueue : public ICommandQueue
 {
     MOCK_METHOD(void, push, (KioskCommand cmd), (override));
-    MOCK_METHOD(KioskCommand, pop, (), (override));
+    MOCK_METHOD(std::optional<KioskCommand>, pop, (), (override));
 };
 
 // now I write the test base class, that uses the mocks to create a kiosk
@@ -34,6 +40,7 @@ class KioskCoordsTest : public ::testing::Test
 {
 public:
     MockQueue queue;
+    MockLogger mock_logger;
     MockArm mock_arm;
     MockView mock_view;
     std::unique_ptr<Kiosk> kiosk;
@@ -41,7 +48,7 @@ public:
 protected:
     void SetUp() override
     {
-        kiosk = std::make_unique<Kiosk>(queue, mock_view, mock_arm, 5, 5);
+        kiosk = std::make_unique<Kiosk>(queue, mock_view, mock_arm, mock_logger, 5, 5);
     }
 };
 


### PR DESCRIPTION
The threads that handle the arm and the use inactive watchdog have been removed. The main thread now handles them in a loop with the kiosk system.

To allow the loop running all the time the command queue has been modified. Now it's not blocking anymore. Being called at every cycle, the queue returns either a command or nothing.